### PR TITLE
docs: add deployment tutorial under kata-cli guide

### DIFF
--- a/docs/kata-cli/deployment-tutorial.md
+++ b/docs/kata-cli/deployment-tutorial.md
@@ -6,7 +6,7 @@ prev: kata-cli-nlu-project
 
 Follow these following steps to deploy your project to messaging channels.
 
-**1. Create a Deployment**
+## 1. Create a Deployment
 
 Create a new deployment version using these command. If you do not specificy the major/minor/patch, it will automatically create a deployment with patch.
 
@@ -14,7 +14,7 @@ Create a new deployment version using these command. If you do not specificy the
 ➜  kata create-deployment [major | minor | patch]
 ```
 
-**2. Add and Update Environment**
+## 2. Add and Update Environment
 
 After having the deployment, create an environment. We provide 3 environment (Development, Staging, Production) that you can choose upon creating an environment.
 
@@ -28,70 +28,10 @@ If you already have environment, simply update them with the newer deployment ve
 ➜  kata update-environment <newDeploymentVersion>
 ```
 
-**3. Add Channels**
+## 3. Add Channels
 
 We now can create messaging channels after you have environment. Add channel with your custom channel name. Choose the environment and channel type from the command line.
 
 ```shell
 ➜  kata add-channel <channelName>
-```
-
-# NLU Project
-
-An NLU must be under a project. Therefore, we need to define a project, before we create an NLU.
-
-## Command Listings
-
-| Commands                    | Functionalities                                                                               |
-| --------------------------- | --------------------------------------------------------------------------------------------- |
-| `kata nl-init`              | to initialize nl definition                                                                   |
-| `kata nl-push`              | to push nl changes                                                                            |
-| `kata nl-pull`              | to pull nl changes from remote                                                                |
-| `kata nl-train [options]`   | to train a sentence or a batch of sentences. `[options]` can be `-f <trainPath/fileName.txt>` |
-| `kata nl-predict [options]` | to predict a sentence. `[options]` can be `[-f <predictPath/fileName.txt>]`                   |
-| `kata list-profiles`        | to list all profiles                                                                          |
-| `kata nl-snapshot`          | to save the nlu snapshot                                                                      |
-
-## NLU Project Best Practice
-
-### Initialize NLU Project
-
-It would create a new file `nlu.yml` in which the nlu structure can be defined.
-
-```shell
-# initialize a nlu project
-➜  kata nl-init
-```
-
-### Push NLU
-
-To use push command to create and update the NLU
-
-```shell
-# push current nlu project
-➜  kata nl-push
-```
-
-### List Profiles
-
-To list all profiles
-
-```shell
-➜  kata list-profiles
-```
-
-### Train NLU
-
-To train a nlu.
-
-```shell
-➜  kata nl-train [-f <trainPath/filename.txt>]
-➜  kata nl-train [-s <sentence>]
-```
-
-### Predict Sentences with NLU
-
-```shell
-➜  kata nl-predict [-f <trainPath/filename.txt>]
-➜  kata nl-predict [-s <sentence>]
 ```

--- a/docs/kata-cli/deployment-tutorial.md
+++ b/docs/kata-cli/deployment-tutorial.md
@@ -1,13 +1,46 @@
 ---
-id: kata-cli-nlu-project
-title: NLU Project
-prev: kata-cli-best-practice
-next: deployment-tutorial
+id: deployment-tutorial
+title: Deployment Tutorial
+prev: kata-cli-nlu-project
 ---
+
+Follow these following steps to deploy your project to messaging channels.
+
+**1. Create a Deployment**
+
+Create a new deployment version using these command. If you do not specificy the major/minor/patch, it will automatically create a deployment with patch.
+
+```shell
+➜  kata create-deployment [major | minor | patch]
+```
+
+**2. Add and Update Environment**
+
+After having the deployment, create an environment. We provide 3 environment (Development, Staging, Production) that you can choose upon creating an environment.
+
+```shell
+➜  kata create-environment <slug>
+```
+
+If you already have environment, simply update them with the newer deployment version. Select the environment that you want to update from the list provided in command line.
+
+```shell
+➜  kata update-environment <newDeploymentVersion>
+```
+
+**3. Add Channels**
+
+We now can create messaging channels after you have environment. Add channel with your custom channel name. Choose the environment and channel type from the command line.
+
+```shell
+➜  kata add-channel <channelName>
+```
+
+# NLU Project
 
 An NLU must be under a project. Therefore, we need to define a project, before we create an NLU.
 
-## Command listings
+## Command Listings
 
 | Commands                    | Functionalities                                                                               |
 | --------------------------- | --------------------------------------------------------------------------------------------- |
@@ -58,7 +91,7 @@ To train a nlu.
 
 ### Predict Sentences with NLU
 
-```
+```shell
 ➜  kata nl-predict [-f <trainPath/filename.txt>]
 ➜  kata nl-predict [-s <sentence>]
 ```

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -191,6 +191,11 @@
         "id": "kata-cli-nlu-project",
         "slug": "/kata-cli/nlu-project/",
         "title": "NLU Project"
+      },
+      {
+        "id": "deployment-tutorial",
+        "slug": "/kata-cli/deployment-tutorial/",
+        "title": "Deployment Tutorial"
       }
     ]
   },


### PR DESCRIPTION
PR ini menambahkan `Deployment Tutorial` under `Kata CLI Guide`
https://github.com/kata-ai/kata-cli/blob/96edb53373228871fb809746f826dea758516d7a/README.md#deploy-your-project